### PR TITLE
Way to know when all hooks are active

### DIFF
--- a/common/src/main/java/me/lojosho/hibiscuscommons/api/events/AllHooksActiveEvent.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/api/events/AllHooksActiveEvent.java
@@ -1,0 +1,19 @@
+package me.lojosho.hibiscuscommons.api.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class AllHooksActiveEvent extends Event {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/common/src/main/java/me/lojosho/hibiscuscommons/api/events/HibiscusHooksAllActiveEvent.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/api/events/HibiscusHooksAllActiveEvent.java
@@ -4,7 +4,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
-public class AllHooksActiveEvent extends Event {
+public class HibiscusHooksAllActiveEvent extends Event {
 
     private static final HandlerList HANDLER_LIST = new HandlerList();
 

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/Hook.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/Hook.java
@@ -10,8 +10,11 @@ import org.jetbrains.annotations.Nullable;
  * Represents a hook into other minecraft plugins
  */
 public abstract class Hook implements Listener {
+
     private final String id;
+
     private boolean active = false;
+
     private boolean itemHook = false;
     private boolean entityHook = false;
 
@@ -27,6 +30,7 @@ public abstract class Hook implements Listener {
                     break;
             }
         }
+
         Hooks.addHook(this);
     }
 
@@ -35,10 +39,11 @@ public abstract class Hook implements Listener {
      *
      * @implNote By default, this method does nothing. It should be overridden by child classes to implement any necessary loading logic
      */
-    public void load() { }
+    public void load() {}
 
     /**
      * Gets an {@link ItemStack} that is associated with the provided id from the hooked plugin
+     *
      * @param itemId The id of the {@link ItemStack}
      * @return The {@link ItemStack} with the id provided. If an invalid id was provided or if the hook doesn't have any related {@link ItemStack}s then this will return null
      * @implNote By default, this method returns null. It should be overridden by child classes if you will to have your hook return a related {@link ItemStack}
@@ -60,6 +65,7 @@ public abstract class Hook implements Listener {
 
     /**
      * Gets whether this hook has been activated
+     *
      * @return true if this hook is active, false otherwise
      * @deprecated As of release 2.2.5+, replaced by {@link #isActive()}
      */
@@ -70,6 +76,7 @@ public abstract class Hook implements Listener {
 
     /**
      * Gets whether this hook has been activated
+     *
      * @return true if this hook is active, false otherwise
      * @since 2.2.5
      */
@@ -79,16 +86,21 @@ public abstract class Hook implements Listener {
 
     /**
      * Sets whether this hook is active
+     *
      * @param active true to activate the hook, false otherwise
      */
     public final void setActive(boolean active) {
         this.active = active;
+
+        if (active) {
+            Hooks.checkHookLoadingStatus();
+        }
     }
 
     /**
      * Whether the method {@link #getItem(String)} should return a non-null value
-     * @return true if {@link #getItem(String)} should return a non-null value, false otherwise
      *
+     * @return true if {@link #getItem(String)} should return a non-null value, false otherwise
      * @apiNote Even though this method returns true does not mean that {@link #getItem(String)} won't return null, rather if this returns false then {@link #getItem(String)} should return false everytime
      */
     public final boolean hasEnabledItemHook() {
@@ -101,6 +113,7 @@ public abstract class Hook implements Listener {
 
     /**
      * Sets whether the method {@link #getItem(String)} should return a non-null value
+     *
      * @param enabled true if {@link #getItem(String)} should return a non-null value, false otherwise
      */
     public final void setEnabledItemHook(boolean enabled) {

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/Hooks.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/Hooks.java
@@ -3,6 +3,7 @@ package me.lojosho.hibiscuscommons.hooks;
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.lojosho.hibiscuscommons.HibiscusCommonsPlugin;
+import me.lojosho.hibiscuscommons.api.events.AllHooksActiveEvent;
 import me.lojosho.hibiscuscommons.hooks.items.*;
 import me.lojosho.hibiscuscommons.hooks.misc.*;
 import me.lojosho.hibiscuscommons.hooks.placeholders.HookPlaceholderAPI;
@@ -15,10 +16,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class Hooks {
 
-    private static final HashMap<String, Hook> hooks = new HashMap<>();
+    private static final HashMap<String, Hook> HOOK_POOL = new HashMap<>();
+
     private static final HookNexo NEXO_HOOK = new HookNexo();
     private static final HookOraxen ORAXEN_HOOK = new HookOraxen();
     private static final HookItemAdder ITEMADDER_HOOK = new HookItemAdder();
@@ -37,16 +40,19 @@ public class Hooks {
     private static final HookCustomFishing CF_HOOK = new HookCustomFishing();
     private static final HookGSit GSIT_HOOK = new HookGSit();
 
+    private static final Map<String, Hook> HOOKED = new HashMap<>();
+    private static boolean allHooksActive = false;
+
     public static Hook getHook(@NotNull String id) {
-        return hooks.get(id.toLowerCase());
+        return HOOK_POOL.get(id.toLowerCase());
     }
 
     public static boolean isItemHook(@NotNull String id) {
-        return hooks.containsKey(id.toLowerCase());
+        return HOOK_POOL.containsKey(id.toLowerCase());
     }
 
     public static void addHook(Hook hook) {
-        hooks.put(hook.getId().toLowerCase(), hook);
+        HOOK_POOL.put(hook.getId().toLowerCase(), hook);
     }
 
     public static void addPlaceholderAPI(PlaceholderExpansion expansion) {
@@ -63,14 +69,36 @@ public class Hooks {
     }
 
     public static void setup() {
-        for (Hook hook : hooks.values()) {
+        for (Hook hook : HOOK_POOL.values()) {
             if (Bukkit.getPluginManager().getPlugin(hook.getId()) != null) {
                 HibiscusCommonsPlugin.getInstance().getServer().getPluginManager().registerEvents(hook, HibiscusCommonsPlugin.getInstance());
-                hook.setActive(true);
                 hook.load();
+
+                HOOKED.put(hook.getId(), hook);
+
                 HibiscusCommonsPlugin.getInstance().getLogger().info("Successfully hooked into " + hook.getId());
             }
         }
+    }
+
+    /**
+     * Checks if all hooked hooks are actually active
+     * so {@link AllHooksActiveEvent} is called.
+     * This is an operation that occurs only once to allow plugins
+     * load their stuff successfully when all hooks are active.
+     */
+    static void checkHookLoadingStatus() {
+        if (allHooksActive) {
+            return;
+        }
+
+        if (!HOOKED.values().stream()
+                .allMatch(Hook::isActive)) {
+            return;
+        }
+
+        allHooksActive = true;
+        Bukkit.getPluginManager().callEvent(new AllHooksActiveEvent());
     }
 
     @Nullable
@@ -93,7 +121,7 @@ public class Hooks {
     }
 
     public static String getStringItem(ItemStack itemStack) {
-        for (Hook hook : hooks.values()) {
+        for (Hook hook : HOOK_POOL.values()) {
             if (hook.isActive() && hook.hasEnabledItemHook()) {
                 String stringyItem = hook.getItemString(itemStack);
                 if (stringyItem == null) continue;
@@ -104,7 +132,7 @@ public class Hooks {
     }
 
     public static String getStringEntity(Entity entity) {
-        for (Hook hook : hooks.values()) {
+        for (Hook hook : HOOK_POOL.values()) {
             if (hook.isActive() && hook.hasEnabledEntityHook()) {
                 String stringyEntity = hook.getEntityString(entity);
                 if (stringyEntity != null) return hook.getId() + ":" + stringyEntity;

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/Hooks.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/Hooks.java
@@ -3,7 +3,7 @@ package me.lojosho.hibiscuscommons.hooks;
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import me.lojosho.hibiscuscommons.HibiscusCommonsPlugin;
-import me.lojosho.hibiscuscommons.api.events.AllHooksActiveEvent;
+import me.lojosho.hibiscuscommons.api.events.HibiscusHooksAllActiveEvent;
 import me.lojosho.hibiscuscommons.hooks.items.*;
 import me.lojosho.hibiscuscommons.hooks.misc.*;
 import me.lojosho.hibiscuscommons.hooks.placeholders.HookPlaceholderAPI;
@@ -83,7 +83,7 @@ public class Hooks {
 
     /**
      * Checks if all hooked hooks are actually active
-     * so {@link AllHooksActiveEvent} is called.
+     * so {@link HibiscusHooksAllActiveEvent} is called.
      * This is an operation that occurs only once to allow plugins
      * load their stuff successfully when all hooks are active.
      */
@@ -98,7 +98,7 @@ public class Hooks {
         }
 
         allHooksActive = true;
-        Bukkit.getPluginManager().callEvent(new AllHooksActiveEvent());
+        Bukkit.getPluginManager().callEvent(new HibiscusHooksAllActiveEvent());
     }
 
     @Nullable

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookDenizen.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookDenizen.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookDenizen extends Hook {
     public HookDenizen() {
         super("denizen", HookFlag.ITEM_SUPPORT);
+        setActive(true);
     }
 
     /**

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookEco.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookEco.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookEco extends Hook {
     public HookEco() {
         super("Eco", HookFlag.ITEM_SUPPORT);
+        setActive(true);
     }
 
     @Override

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookGeary.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookGeary.java
@@ -21,6 +21,7 @@ public class HookGeary extends Hook {
 
     public HookGeary() {
         super("geary", HookFlag.ITEM_SUPPORT);
+        setActive(true);
     }
 
     /**

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookItemAdder.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookItemAdder.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
  */
 @SuppressWarnings("SpellCheckingInspection")
 public class HookItemAdder extends Hook {
-    private boolean enabled = false;
 
     public HookItemAdder() {
         super("itemsadder", HookFlag.ITEM_SUPPORT);
@@ -32,7 +31,7 @@ public class HookItemAdder extends Hook {
      */
     @Override
     public ItemStack getItem(@NotNull String itemId) {
-        if (enabled) {
+        if (isActive()) {
             CustomStack stack = CustomStack.getInstance(itemId);
             if (stack == null) return null;
             return stack.getItemStack().clone();
@@ -43,10 +42,13 @@ public class HookItemAdder extends Hook {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onItemAdderDataLoad(ItemsAdderLoadDataEvent event) {
-        HibiscusHookReload.ReloadType reloadType = enabled ? HibiscusHookReload.ReloadType.RELOAD : HibiscusHookReload.ReloadType.INITIAL;
-        this.enabled = true;
-        HibiscusHookReload newEvent = new HibiscusHookReload(this, reloadType);
-        Bukkit.getPluginManager().callEvent(newEvent);
+        HibiscusHookReload.ReloadType type = HibiscusHookReload.ReloadType.RELOAD;
+        if (!isActive()) {
+            type = HibiscusHookReload.ReloadType.INITIAL;
+            setActive(true);
+        }
+
+        Bukkit.getPluginManager().callEvent(new HibiscusHookReload(this, type));
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -69,7 +71,14 @@ public class HookItemAdder extends Hook {
         return CustomStack.byItemStack(itemStack).getId();
     }
 
+    /**
+     * Checks if ItemsAdder hook is enabled
+     * @return whether ItemsAdder hook is enabled or not
+     * @deprecated as you can just check if the hook is active
+     * by calling {@link #isActive()}
+     */
+    @Deprecated
     public boolean getIAEnabled() {
-        return enabled;
+        return isActive();
     }
 }

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookMMOItems.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookMMOItems.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookMMOItems extends Hook {
     public HookMMOItems() {
         super("MMOItems", HookFlag.ITEM_SUPPORT);
+        setActive(true);
     }
 
     @Override

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookMythic.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookMythic.java
@@ -9,16 +9,17 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A hook that integrates the plugin {@link io.lumine.mythic.bukkit.MythicBukkit MythicBukkit} to provide custom items
+ * A hook that integrates the plugin {@link MythicBukkit MythicBukkit} to provide custom items
  */
 @SuppressWarnings("SpellCheckingInspection")
 public class HookMythic extends Hook {
     public HookMythic() {
         super("mythicmobs", HookFlag.ITEM_SUPPORT, HookFlag.ENTITY_SUPPORT);
+        setActive(true);
     }
 
     /**
-     * Gets a cosmetic {@link ItemStack} that is associated with the provided id from the plugin {@link io.lumine.mythic.bukkit.MythicBukkit MythicBukkit}
+     * Gets a cosmetic {@link ItemStack} that is associated with the provided id from the plugin {@link MythicBukkit MythicBukkit}
      */
     @Override
     public ItemStack getItem(@NotNull String itemId) {

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookNexo.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookNexo.java
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
  */
 @SuppressWarnings("SpellCheckingInspection")
 public class HookNexo extends Hook {
-    private boolean enabled = false;
+
     public HookNexo() {
         super("nexo", HookFlag.ITEM_SUPPORT);
     }
@@ -27,7 +27,7 @@ public class HookNexo extends Hook {
      */
     @Override
     public ItemStack getItem(@NotNull String itemId) {
-        return NexoItems.optionalItemFromId(itemId).map(ItemBuilder::build).orElse(enabled ? new ItemStack(Material.AIR) : null);
+        return NexoItems.optionalItemFromId(itemId).map(ItemBuilder::build).orElse(isActive() ? new ItemStack(Material.AIR) : null);
     }
 
     @Override
@@ -39,9 +39,12 @@ public class HookNexo extends Hook {
 
     @EventHandler
     public void onLoadItems(NexoItemsLoadedEvent event) {
-        HibiscusHookReload.ReloadType reloadType = enabled ? HibiscusHookReload.ReloadType.RELOAD : HibiscusHookReload.ReloadType.INITIAL;
-        this.enabled = true;
-        HibiscusHookReload newEvent = new HibiscusHookReload(this, reloadType);
-        Bukkit.getPluginManager().callEvent(newEvent);
+        HibiscusHookReload.ReloadType type = HibiscusHookReload.ReloadType.RELOAD;
+        if (!isActive()) {
+            type = HibiscusHookReload.ReloadType.INITIAL;
+            setActive(true);
+        }
+
+        Bukkit.getPluginManager().callEvent(new HibiscusHookReload(this, type));
     }
 }

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookOraxen.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/items/HookOraxen.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookOraxen extends Hook {
     public HookOraxen() {
         super("oraxen", HookFlag.ITEM_SUPPORT);
+        setActive(true);
     }
 
     /**

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookCMI.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookCMI.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookCMI extends Hook {
     public HookCMI() {
         super("CMI");
+        setActive(true);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookCustomFishing.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookCustomFishing.java
@@ -12,6 +12,7 @@ public class HookCustomFishing extends Hook {
 
     public HookCustomFishing() {
         super("CustomFishing");
+        setActive(true);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookGSit.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookGSit.java
@@ -12,6 +12,7 @@ public class HookGSit extends Hook {
 
     public HookGSit() {
         super("GSit");
+        setActive(true);
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookHMCColor.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookHMCColor.java
@@ -6,5 +6,6 @@ import me.lojosho.hibiscuscommons.hooks.Hook;
 public class HookHMCColor extends Hook {
     public HookHMCColor() {
         super("HMCColor");
+        setActive(true);
     }
 }

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookLibsDisguises.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookLibsDisguises.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookLibsDisguises extends Hook {
     public HookLibsDisguises() {
         super("LibsDisguises");
+        setActive(true);
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookModelEngine.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookModelEngine.java
@@ -9,6 +9,7 @@ public class HookModelEngine extends Hook {
 
     public HookModelEngine() {
         super("ModelEngine");
+        setActive(true);
     }
 
     @Override

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookPremiumVanish.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookPremiumVanish.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookPremiumVanish extends Hook {
     public HookPremiumVanish() {
         super("PremiumVanish");
+        setActive(true);
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookSuperVanish.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/misc/HookSuperVanish.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.NotNull;
 public class HookSuperVanish extends Hook {
     public HookSuperVanish() {
         super("SuperVanish");
+        setActive(true);
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/common/src/main/java/me/lojosho/hibiscuscommons/hooks/placeholders/HookPlaceholderAPI.java
+++ b/common/src/main/java/me/lojosho/hibiscuscommons/hooks/placeholders/HookPlaceholderAPI.java
@@ -11,6 +11,7 @@ public class HookPlaceholderAPI extends Hook {
 
     public HookPlaceholderAPI() {
         super("PlaceholderAPI");
+        setActive(true);
     }
 
     public void registerPlaceholder(PlaceholderExpansion placeholderExpansion) {


### PR DESCRIPTION
Basically added a way to differentiate between all available hooks supported by HibiscusCommons and the ones that are actually active (active meaning that the plugin is enabled when the setup method is called and is marked as active, some hooks need to wait to actually be marked as so).