### PR TITLE
fix: remove player from NPC scoreboard team to prevent TAB sorting conflict

### DIFF
--- a/v1_21_R3/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R3/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
+++ b/v1_21_R3/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R3/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
@@ -32,7 +32,6 @@ public class PlayerScoreboardTeamAddPlayersWrapper extends PlayerScoreboardTeamW
         //Adding players to the team (You have to use the NPC's name, and add it to a list)
         return ClientboundSetPlayerTeamPacket.createMultiplePlayerPacket(team, new ArrayList<String>() {{
             add(name);
-            add(player.getName());
         }}, ClientboundSetPlayerTeamPacket.Action.ADD);
     }
 }

--- a/v1_21_R4/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R4/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
+++ b/v1_21_R4/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R4/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
@@ -32,7 +32,6 @@ public class PlayerScoreboardTeamAddPlayersWrapper extends PlayerScoreboardTeamW
         //Adding players to the team (You have to use the NPC's name, and add it to a list)
         return ClientboundSetPlayerTeamPacket.createMultiplePlayerPacket(team, new ArrayList<String>() {{
             add(name);
-            add(player.getName());
         }}, ClientboundSetPlayerTeamPacket.Action.ADD);
     }
 }

--- a/v1_21_R5/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R5/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
+++ b/v1_21_R5/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R5/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
@@ -32,7 +32,6 @@ public class PlayerScoreboardTeamAddPlayersWrapper extends PlayerScoreboardTeamW
         //Adding players to the team (You have to use the NPC's name, and add it to a list)
         return ClientboundSetPlayerTeamPacket.createMultiplePlayerPacket(team, new ArrayList<String>() {{
             add(name);
-            add(player.getName());
         }}, ClientboundSetPlayerTeamPacket.Action.ADD);
     }
 }

--- a/v1_21_R6/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R6/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
+++ b/v1_21_R6/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R6/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
@@ -32,7 +32,6 @@ public class PlayerScoreboardTeamAddPlayersWrapper extends PlayerScoreboardTeamW
         //Adding players to the team (You have to use the NPC's name, and add it to a list)
         return ClientboundSetPlayerTeamPacket.createMultiplePlayerPacket(team, new ArrayList<String>() {{
             add(name);
-            add(player.getName());
         }}, ClientboundSetPlayerTeamPacket.Action.ADD);
     }
 }

--- a/v1_21_R7/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R7/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
+++ b/v1_21_R7/src/main/java/me/lojosho/hibiscuscommons/nms/v1_21_R7/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
@@ -32,7 +32,6 @@ public class PlayerScoreboardTeamAddPlayersWrapper extends PlayerScoreboardTeamW
         //Adding players to the team (You have to use the NPC's name, and add it to a list)
         return ClientboundSetPlayerTeamPacket.createMultiplePlayerPacket(team, new ArrayList<String>() {{
             add(name);
-            add(player.getName());
         }}, ClientboundSetPlayerTeamPacket.Action.ADD);
     }
 }

--- a/v26_1_R1/src/main/java/me/lojosho/hibiscuscommons/nms/v26_1_R1/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
+++ b/v26_1_R1/src/main/java/me/lojosho/hibiscuscommons/nms/v26_1_R1/packets/wrapper/PlayerScoreboardTeamAddPlayersWrapper.java
@@ -32,7 +32,6 @@ public class PlayerScoreboardTeamAddPlayersWrapper extends PlayerScoreboardTeamW
         //Adding players to the team (You have to use the NPC's name, and add it to a list)
         return ClientboundSetPlayerTeamPacket.createMultiplePlayerPacket(team, new ArrayList<String>() {{
             add(name);
-            add(player.getName());
         }}, ClientboundSetPlayerTeamPacket.Action.ADD);
     }
 }


### PR DESCRIPTION
The PlayerScoreboardTeamAddPlayersWrapper was adding both the NPC name and the real player's name to the nametag-hiding team. Since Minecraft only allows a player to be in one scoreboard team at a time, this removed the player from TAB plugin's sorting team, causing them to lose their TAB priority after using the wardrobe.Only the NPC name needs to be in the team to hide its nametag.